### PR TITLE
Add runtime_identifier to entity description

### DIFF
--- a/src/Lib/Internal/BehaviorPack/Entity.ts
+++ b/src/Lib/Internal/BehaviorPack/Entity.ts
@@ -41,6 +41,8 @@ export interface EntityDescription extends ScriptContainer {
   /** */
   is_experimental: boolean;
   /** */
+  runtime_identifier: string;
+  /** */
   properties?: Record<string, any>;
 }
 


### PR DESCRIPTION
Did this so I can use it in the diagnoser, hopefully the right way to go about it